### PR TITLE
Exclude build folder from phpcs

### DIFF
--- a/phpcs.xml.mustache
+++ b/phpcs.xml.mustache
@@ -5,6 +5,7 @@
 	<!-- Exclude paths -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
 	<exclude-pattern>**/**.js</exclude-pattern>
 
 	<!-- Configs -->


### PR DESCRIPTION
This PR aims to exclude the `build` folder from being targeted by `phpcs` and `phpcbf`.