### PR TITLE
Updates to spoiler files and remove unnecessary imports from PHP templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
 		dashicon: 'palmtree',
 		version: '1.0.0',
 		npmDependencies: [
-			"@wordpress/icons@^9.22.0",
+			"@wordpress/icons@^10.13.0",
 			"lodash@^4.17.21",
 		],
 		customScripts: {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
 		npmDevDependencies: [
 			"@woocommerce/dependency-extraction-webpack-plugin@^3.0.1",
 			"@woocommerce/eslint-plugin@^2.3.0",
-			"@wordpress/prettier-config@^4.13.0",
+			"@wordpress/prettier-config@^4.14.0",
 			"@wordpress/scripts@^30.6.0",
 			"@wordpress/env@^10.13.0"
 		],

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
 			"@woocommerce/dependency-extraction-webpack-plugin@^3.0.1",
 			"@woocommerce/eslint-plugin@^2.3.0",
 			"@wordpress/prettier-config@^4.14.0",
-			"@wordpress/scripts@^30.6.0",
+			"@wordpress/scripts@^30.7.0",
 			"@wordpress/env@^10.13.0"
 		],
 	},

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 			"env": "wp-env"
 		},
 		npmDevDependencies: [
-			"@woocommerce/dependency-extraction-webpack-plugin@^3.0.",
+			"@woocommerce/dependency-extraction-webpack-plugin@^3.0.1",
 			"@woocommerce/eslint-plugin@^2.3.0",
 			"@wordpress/prettier-config@^4.13.0",
 			"@wordpress/scripts@^30.6.0",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 			"@woocommerce/eslint-plugin@^2.3.0",
 			"@wordpress/prettier-config@^4.14.0",
 			"@wordpress/scripts@^30.7.0",
-			"@wordpress/env@^10.13.0"
+			"@wordpress/env@^10.14.0"
 		],
 	},
 };

--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ module.exports = {
 			"env": "wp-env"
 		},
 		npmDevDependencies: [
-			"@woocommerce/dependency-extraction-webpack-plugin@^2.2.0",
-			"@woocommerce/eslint-plugin@^2.2.0",
-			"@wordpress/prettier-config@^2.14.0",
-			"@wordpress/scripts@^26.2.0",
-			"@wordpress/env@^7.0.0"
+			"@woocommerce/dependency-extraction-webpack-plugin@^3.0.",
+			"@woocommerce/eslint-plugin@^2.3.0",
+			"@wordpress/prettier-config@^4.13.0",
+			"@wordpress/scripts@^30.6.0",
+			"@wordpress/env@^10.13.0"
 		],
 	},
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
 		dashicon: 'palmtree',
 		version: '1.0.0',
 		npmDependencies: [
-			"@wordpress/icons@^10.13.0",
+			"@wordpress/icons@^10.14.0",
 			"lodash@^4.17.21",
 		],
 		customScripts: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "shipping-workshop",
-	"version": "0.1.14",
+	"version": "0.1.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "shipping-workshop",
-			"version": "0.1.14",
+			"version": "0.1.15",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/icons": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wceu23-shipping-workshop",
-	"version": "0.1.14",
+	"version": "0.1.15",
 	"author": "Thomas Roberts and Niels Lange",
 	"license": "GPL-2.0-or-later",
 	"main": "index.js",

--- a/shipping-workshop-extend-store-endpoint.php.mustache
+++ b/shipping-workshop-extend-store-endpoint.php.mustache
@@ -1,6 +1,4 @@
 <?php
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CheckoutSchema;
 
 /**
@@ -36,7 +34,7 @@ class Shipping_Workshop_Extend_Store_Endpoint {
 	public static function extend_store() {
 		/**
 		 * [backend-step-02]
-		 * 📝 Once the `extend_checkout_schema` method is complete (see [backend-step-01]) you can 
+		 * 📝 Once the `extend_checkout_schema` method is complete (see [backend-step-01]) you can
 		 * uncomment the code below.
 		 */
         /*

--- a/shipping-workshop.php.mustache
+++ b/shipping-workshop.php.mustache
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 add_action( 'plugin_row_meta', 'wceu23_shipping_workshop_add_plugin_links', 10, 2 );
 function wceu23_shipping_workshop_add_plugin_links( $links, $file ) {
 	if ( basename( dirname(__FILE__ ) ) . '/' . basename( __FILE__ ) !== $file ) {
-		return;
+		return $links;
 	}
 	$links[] = '<a href="https://github.com/woocommerce/wceu23-shipping-workshop-starter">' . __( 'Workshop starter files', 'shipping-workshop' ) . '</a>';
 	$links[] = '<a href="https://github.com/woocommerce/wceu23-shipping-workshop-final">' . __( 'Workshop final files', 'shipping-workshop' ) . '</a>';

--- a/shipping-workshop.php.mustache
+++ b/shipping-workshop.php.mustache
@@ -6,6 +6,7 @@
  * License:         GPL-2.0-or-later
  * License URI:     https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:     shipping-workshop
+ * Description:     A tutorial plugin to extend the Checkout block by adding a "not at home" shipping option.
  *
  * @package         create-block
  */

--- a/shipping-workshop.php.mustache
+++ b/shipping-workshop.php.mustache
@@ -14,6 +14,17 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+add_action( 'plugin_row_meta', 'wceu23_shipping_workshop_add_plugin_links', 10, 2 );
+function wceu23_shipping_workshop_add_plugin_links( $links, $file ) {
+	if ( basename( dirname(__FILE__ ) ) . '/' . basename( __FILE__ ) !== $file ) {
+		return;
+	}
+	$links[] = '<a href="https://github.com/woocommerce/wceu23-shipping-workshop-starter">' . __( 'Workshop starter files', 'shipping-workshop' ) . '</a>';
+	$links[] = '<a href="https://github.com/woocommerce/wceu23-shipping-workshop-final">' . __( 'Workshop final files', 'shipping-workshop' ) . '</a>';
+	$links[] = '<a href="https://developer.woocommerce.com/2023/08/07/extending-the-woocommerce-checkout-block-to-add-custom-shipping-options/">' . __( 'Video tutorial', 'shipping-workshop' ) . '</a>';
+	return $links;
+}
+
 // Define SHIPPING_WORKSHOP_VERSION.
 $plugin_data = get_file_data( __FILE__, array( 'version' => 'version' ) );
 define( 'SHIPPING_WORKSHOP_VERSION', $plugin_data['version'] );

--- a/spoilers/frontend-step-04-extra-credit.md.mustache
+++ b/spoilers/frontend-step-04-extra-credit.md.mustache
@@ -3,9 +3,7 @@ if (
     selectedAlternateShippingInstruction !== 'other' ||
     otherShippingValue !== ''
 ) {
-    if ( validationError ) {
-        clearValidationError( validationErrorId );
-    }
+    clearValidationError( validationErrorId );
     return;
 }
 ```

--- a/spoilers/frontend-step-05.md.mustache
+++ b/spoilers/frontend-step-05.md.mustache
@@ -1,11 +1,11 @@
 ```jsx
 if (
-    selectedAlternateShippingInstruction !== 'other' ||
-    otherShippingValue !== ''
+	selectedAlternateShippingInstruction !== 'other' ||
+	otherShippingValue !== ''
 ) {
-    if ( validationError ) {
-        clearValidationError( validationErrorId );
-    }
+	if ( validationError ) {
+		clearValidationError( validationErrorId );
+	}
     return;
 }
 ```

--- a/spoilers/frontend-step-07-extra-credit.md.mustache
+++ b/spoilers/frontend-step-07-extra-credit.md.mustache
@@ -1,3 +1,11 @@
 ```jsx
-TBD
+if (
+    selectedAlternateShippingInstruction !== 'other' ||
+    otherShippingValue !== ''
+) {
+    if ( validationError ) {
+        clearValidationError( validationErrorId );
+    }
+    return;
+}
 ```


### PR DESCRIPTION
This PR improves some of the spoilers and removes unused imports from the PHP template files.

Many thanks to @lisa-webDev for making the changes in https://github.com/woocommerce/wceu23-shipping-workshop-final/pull/10/files

To test
1. Clone this repo into your `wp-content/plugins` directory and open a terminal in the same directory.
2. Ensure you don't have the `wceu23-shipping-workshop-final` plugin activated.
3. Run `npx @wordpress/create-block -t ./wceu23-shipping-workshop-starter/ test-shipping-workshop`
4. Ensure it installs correctly (note: there is an error about dependencies on the prettier step, this can be skipped for now)
5. Open the WordPress dashboard and enable the plugin
6. Ensure no fatal errors happen on page load.